### PR TITLE
Fix MCP settings payload parsing and PATCH update flow

### DIFF
--- a/app/api/agent/mcp/servers/[serverId]/settings/route.ts
+++ b/app/api/agent/mcp/servers/[serverId]/settings/route.ts
@@ -20,7 +20,7 @@ export async function GET(
   });
 }
 
-export async function PUT(
+export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ serverId: string }> }
 ) {
@@ -31,7 +31,7 @@ export async function PUT(
     request,
     backendPath: `/mcp/servers/${serverId}/settings`,
     init: {
-      method: "PUT",
+      method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
     },

--- a/app/api/agent/mcp/servers/route.ts
+++ b/app/api/agent/mcp/servers/route.ts
@@ -9,8 +9,7 @@ export async function GET(request: NextRequest) {
     backendPath: "/mcp/servers",
     init: {
       method: "GET",
-      cache: "force-cache",
-      next: { tags: [CACHE_TAGS.mcpServers] },
+      cache: "no-store",
     },
     fallbackError: "Could not load MCP servers.",
   });

--- a/app/settings/mcp/mcp-client.tsx
+++ b/app/settings/mcp/mcp-client.tsx
@@ -1,34 +1,13 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
 import { ChevronDown, ChevronRight, Settings2 } from "lucide-react";
 import { useChatStore } from "@/lib/stores/chat";
-
-interface MCPServerSettingsSchema {
-  key: string;
-  label: string;
-  type: "string" | "number" | "boolean" | "folder_id" | "spreadsheet_id" | "text";
-  required: boolean;
-  default?: string | number | boolean;
-}
-
-interface MCPServerInfo {
-  id: string;
-  name: string;
-  description: string;
-  tools: string[];
-  default_enabled: boolean;
-  enabled: boolean;
-  source: "builtin" | "custom" | string;
-  requires_connection: string | null;
-  settings_schema: MCPServerSettingsSchema[] | null;
-  settings: Record<string, unknown> | null;
-  editable: boolean;
-}
+import type { MCPServerInfo, MCPServerSettingsSchema } from "@/types";
 
 interface McpClientProps {
   initialServers: MCPServerInfo[];
@@ -36,7 +15,7 @@ interface McpClientProps {
 }
 
 export function McpClient({ initialServers, googleConnected }: McpClientProps) {
-  const { mcpServers, setMcpServers, setMcpServerEnabled, fetchMcpServers } = useChatStore();
+  const { mcpServers, setMcpServers, setMcpServerEnabled } = useChatStore();
   
   // Initialize store with server data
   useEffect(() => {

--- a/app/settings/mcp/page.tsx
+++ b/app/settings/mcp/page.tsx
@@ -2,8 +2,10 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { Suspense } from "react";
 import { McpClient } from "./mcp-client";
+import { mcpServersResponseSchema } from "@/lib/schemas/mcp";
 import { SettingsSkeleton } from "../components/settings-skeleton";
 import { SettingsError } from "../components/settings-error";
+import type { MCPServerInfo } from "@/types";
 
 interface GoogleIntegrationStatus {
   connected: boolean;
@@ -12,28 +14,6 @@ interface GoogleIntegrationStatus {
   connected_by?: string;
   connected_at?: string;
   scopes?: string[];
-}
-
-interface MCPServerSettingsSchema {
-  key: string;
-  label: string;
-  type: "string" | "number" | "boolean" | "folder_id" | "spreadsheet_id" | "text";
-  required: boolean;
-  default?: string | number | boolean;
-}
-
-interface MCPServerInfo {
-  id: string;
-  name: string;
-  description: string;
-  tools: string[];
-  default_enabled: boolean;
-  enabled: boolean;
-  source: "builtin" | "custom" | string;
-  requires_connection: string | null;
-  settings_schema: MCPServerSettingsSchema[] | null;
-  settings: Record<string, unknown> | null;
-  editable: boolean;
 }
 
 async function fetchGoogleStatus(): Promise<GoogleIntegrationStatus | null> {
@@ -75,8 +55,9 @@ async function fetchMcpServers(): Promise<MCPServerInfo[]> {
     throw new Error("Failed to load MCP servers");
   }
 
-  const data = await response.json();
-  return data.servers || [];
+  const payload = await response.json();
+  const parsed = mcpServersResponseSchema.parse(payload);
+  return parsed.servers;
 }
 
 async function McpContent() {

--- a/components/chat/ChatInput.tsx
+++ b/components/chat/ChatInput.tsx
@@ -5,7 +5,7 @@ import { CheckCircle2, Globe, Loader2, Paperclip, Plus, Send, X } from "lucide-r
 
 import { useChatStore } from "@/lib/stores/chat";
 import { useModelStore } from "@/lib/stores/model";
-import { sendChatMessage, updateEnabledMcpServers, uploadReceipt } from "@/lib/api/client";
+import { sendChatMessage, uploadReceipt } from "@/lib/api/client";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import type { ChatAttachmentInput } from "@/types";
@@ -153,7 +153,7 @@ export function ChatInput() {
       }
 
       const { sessionId, currentChatId } = useChatStore.getState();
-      const enabledMcpServers = enabledMcpServerIds;
+      const enabledMcpServers = mcpServers.length > 0 ? enabledMcpServerIds : undefined;
       const response = await sendChatMessage(
         baseUserMessage,
         sessionId,

--- a/lib/schemas/mcp.ts
+++ b/lib/schemas/mcp.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+
+const primitiveFilterValueSchema = z.union([z.string(), z.number(), z.boolean()]);
+
+export const mcpColumnFilterOperatorSchema = z.enum([
+  "equals",
+  "not_equals",
+  "contains",
+  "starts_with",
+  "ends_with",
+  "in",
+  "gt",
+  "gte",
+  "lt",
+  "lte",
+]);
+
+export const mcpColumnFilterSchema = z.object({
+  column: z.string().min(1),
+  operator: mcpColumnFilterOperatorSchema.default("equals"),
+  value: z.union([primitiveFilterValueSchema, z.array(primitiveFilterValueSchema)]),
+  case_sensitive: z.boolean().optional(),
+});
+
+export const mcpServerSettingsSchemaSchema = z.object({
+  key: z.string().min(1),
+  label: z.string().min(1),
+  type: z.enum(["string", "number", "boolean", "folder_id", "spreadsheet_id", "text"]),
+  required: z.boolean(),
+  default: z.union([z.string(), z.number(), z.boolean(), z.null()]).optional(),
+});
+
+export const mcpServerInfoSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string(),
+  tools: z.array(z.string()),
+  default_enabled: z.boolean(),
+  enabled: z.boolean(),
+  source: z.string(),
+  requires_connection: z.string().nullable(),
+  settings_schema: z.array(mcpServerSettingsSchemaSchema).nullable(),
+  settings: z.record(z.string(), z.unknown()).nullable(),
+  editable: z.boolean(),
+});
+
+export const mcpServersResponseSchema = z.object({
+  servers: z.array(mcpServerInfoSchema),
+  enabled_server_ids: z.array(z.string()),
+});
+
+export const mcpEnabledUpdateResponseSchema = z.object({
+  enabled_server_ids: z.array(z.string()),
+});
+
+export const mcpServerSettingsResponseSchema = z.object({
+  mcp_server_id: z.string().min(1),
+  settings: z.record(z.string(), z.unknown()),
+  settings_schema: z.array(mcpServerSettingsSchemaSchema),
+  editable: z.boolean(),
+});
+
+export const mcpServerSettingsUpdateResponseSchema = z.object({
+  mcp_server_id: z.string().min(1),
+  settings: z.record(z.string(), z.unknown()),
+});
+
+export type MCPColumnFilter = z.infer<typeof mcpColumnFilterSchema>;

--- a/types/index.ts
+++ b/types/index.ts
@@ -402,12 +402,33 @@ export interface ModelSelectResponse {
 }
 
 // MCP server configuration types
+export type MCPColumnFilterOperator =
+  | "equals"
+  | "not_equals"
+  | "contains"
+  | "starts_with"
+  | "ends_with"
+  | "in"
+  | "gt"
+  | "gte"
+  | "lt"
+  | "lte";
+
+export type MCPColumnFilterValue = string | number | boolean;
+
+export interface MCPColumnFilter {
+  column: string;
+  operator?: MCPColumnFilterOperator;
+  value: MCPColumnFilterValue | MCPColumnFilterValue[];
+  case_sensitive?: boolean;
+}
+
 export interface MCPServerSettingsSchema {
   key: string;
   label: string;
   type: "string" | "number" | "boolean" | "folder_id" | "spreadsheet_id" | "text";
   required: boolean;
-  default?: string | number | boolean;
+  default?: string | number | boolean | null;
 }
 
 export interface MCPServerInfo {


### PR DESCRIPTION
## Summary
- add MCP Zod schemas and parse MCP API payloads in settings/client API calls
- fix MCP settings page crash when backend returns null defaults in settings metadata
- switch MCP settings update flow to PATCH end-to-end in client
- ensure chat request omits enabled_mcp_servers when server list is unavailable
- improve tool-call rendering in chat for readability (summary + expandable JSON args/result)

## Why
The MCP settings page failed to load because the client schema rejected null defaults returned by backend settings metadata.

## Validation
- npm test (11 tests passing)
- npx eslint on all touched files (no errors)

## Notes
- full-project npm run lint still reports unrelated pre-existing issues outside this diff.