### PR TITLE
Fix: Warning card dark mode contrast

### DIFF
--- a/app/donations/page.tsx
+++ b/app/donations/page.tsx
@@ -53,7 +53,7 @@ export default async function DonationsPage() {
 
       <main className="max-w-5xl mx-auto px-4 py-8 space-y-8">
         {(fetchError || (data.total === 0 && !summaryData)) && (
-          <Card className="border-[var(--warning-200)] bg-[var(--warning-50)] dark:border-[var(--warning-800)] dark:bg-[var(--warning-900)]/20">
+          <Card className="border-[var(--warning-200)] bg-[var(--warning-50)] dark:border-[var(--warning-800)] dark:bg-[var(--warning-900)]">
             <CardContent className="pt-4">
               <p className="text-sm text-[var(--warning-800)] dark:text-[var(--warning-200)]">
                 <strong>Configure Charitable Ledger:</strong> Go to{" "}

--- a/app/hsa/page.tsx
+++ b/app/hsa/page.tsx
@@ -36,7 +36,7 @@ export default async function HSAPage() {
 
       <main className="max-w-5xl mx-auto px-4 py-8">
         {!isConfigured && (
-          <Card className="mb-6 border-[var(--warning-200)] bg-[var(--warning-50)] dark:border-[var(--warning-800)] dark:bg-[var(--warning-900)]/20">
+          <Card className="mb-6 border-[var(--warning-200)] bg-[var(--warning-50)] dark:border-[var(--warning-800)] dark:bg-[var(--warning-900)]">
             <CardContent className="pt-6">
               <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
                 <div className="space-y-2">


### PR DESCRIPTION
## Summary
Fixed dark mode contrast issue for warning cards in HSA and Donations dashboards.

## Changes
- Changed `dark:bg-[var(--warning-900)]/20` (20% opacity) to `dark:bg-[var(--warning-900)]` (solid background) for proper text contrast
- Applied to both HSA Dashboard (`app/hsa/page.tsx`) and Donations page (`app/donations/page.tsx`)

## Testing
- Verified warning cards display correctly in dark mode with readable text